### PR TITLE
Restrict the gem versions we test against

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
 bundler_args: --without development

--- a/Gemfile
+++ b/Gemfile
@@ -2,10 +2,10 @@
 source 'https://rubygems.org'
 
 group :development, :test do
-  gem 'rake'
-  gem 'rspec'
-  gem 'puppetlabs_spec_helper'
-  gem 'rubocop', '~> 0.36.0', require: false
+  gem 'puppetlabs_spec_helper', '~> 1.1.1'
+  gem 'rake', '~> 11.2.0'
+  gem 'rspec', '~> 3.5.0'
+  gem 'rubocop', '~> 0.47.1', require: false
 end
 
 if puppetversion = ENV['PUPPET_GEM_VERSION']


### PR DESCRIPTION
Having unbounded versions as dependencies is a mistake.