### PR TITLE
Fix deprecation warning

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,9 @@
 require 'rspec-puppet'
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+end
+
 require 'puppetlabs_spec_helper/puppet_spec_helper'
 
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))


### PR DESCRIPTION
Before this change running `bundle exec rake spec` resulted in the following warning:

Deprecation Warnings:
puppetlabs_spec_helper: defaults `mock_with` to `:mocha`.

The config option *cannot* be added to an existing block, it has
to be in a seperate block before the gem is loaded to remove
the deprecation.

https://stackoverflow.com/questions/54059220/confusing-rspec-puppet-deprecation-warning-defaults-mock-with-to-mocha
https://tickets.puppetlabs.com/browse/PDK-916