### PR TITLE
Add rubocop action

### DIFF
--- a/.github/config/rubocop_linter_action.yml
+++ b/.github/config/rubocop_linter_action.yml
@@ -1,0 +1,1 @@
+rubocop_fail_level: 'fatal'

--- a/.github/workflows/rubocop-linter.yaml
+++ b/.github/workflows/rubocop-linter.yaml
@@ -1,0 +1,18 @@
+name: Rubocop linter
+
+on:
+  push:
+    branches-ignore:
+      - 'master'
+
+jobs:
+  lint:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Rubocop Linter
+        uses: andrewmcodes/rubocop-linter-action@v3.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This action adds the rubocop failiures via the check UI which makes
them much more prominent on a failing build.