### PR TITLE
Add and configure rspec_honeycomb_formatter

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,3 @@
 --format documentation
+--require rspec_honeycomb_formatter
+--format RSpecHoneycombFormatter

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ group :development, :test do
   gem 'puppetlabs_spec_helper', '~> 2.15.0'
   gem 'rake', '~> 13.0.0'
   gem 'rspec', '~> 3.9.0'
+  gem 'rspec_honeycomb_formatter', '~> 0.2.1'
   gem 'rubocop', '~> 0.88.0', require: false
 end
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ You can install this module from [PuppetForge](https://forge.puppet.com/):
 
     puppet module install deanwilson-ip_in_range
 
+## Honeycomb RSpec Formatter
+
+This repository was used as a test case for the
+[rspec_honeycomb_formatter](https://github.com/puppetlabs/rspec_honeycomb_formatter).
+If you would like to send traces based on the output of your
+`bundle exec rake spec` to Honeycomb you'll need to configure a few environment variables.
+
+    export HONEYCOMB_DATASET=tests # free form text
+    export HONEYCOMB_SERVICE=rspec # free form text
+    export HONEYCOMB_WRITEKEY=${HONEYCOMB_API_KEY} # created on honeycomb account creation
+
+After running the specs you should see the output in the Honeycomb console.
+
 ### License
 
 Apache 2.0 - [Dean Wilson](https://www.unixdaemon.net)


### PR DESCRIPTION
Show how to integrate the RSpec Honeycomb formatter into a puppet modules unit tests.